### PR TITLE
Fix shuffling the fitting parameters

### DIFF
--- a/IVParamFitter.cpp
+++ b/IVParamFitter.cpp
@@ -70,7 +70,7 @@ void IVParamFitter::SeqFit(size_t runCount, const std::valarray<double>& Irex) {
         }
         std::ranges::shuffle(ParSeq, generator);
 
-        double fmin;
+        double fmin = NAN;
         for (size_t j: ParSeq) {
             parameterIndex = j;
             std::tie(par[parameterIndex], fmin) = GoldenMinimize(

--- a/IVParamFitter.h
+++ b/IVParamFitter.h
@@ -11,7 +11,7 @@ class IVParamFitter {
 
     std::valarray<double> par;
     std::valarray<bool> ToFit;
-    size_t iParNum;
+    size_t parameterIndex;
 
 public:
     double operator()(double dParam);


### PR DESCRIPTION
`ParSeq` should contain different integers, which are the indices of the parameters to fit. The order of the indices should be random. The presented code does the job correctly, whereas the former one produced an array of many _identical_ integers.