### PR TITLE
Access the fit parameters by their names

### DIFF
--- a/IVParamFitter.h
+++ b/IVParamFitter.h
@@ -1,17 +1,17 @@
 #ifndef CFOO_H
 #define CFOO_H
 
+#include <string>
+#include <unordered_map>
 #include <valarray>
 
 class IVParamFitter {
-    const size_t parCount = 21;
-
     std::valarray<double> Iexp, Vexp;
     std::valarray<double> Inum, Vnum;
 
-    std::valarray<double> par;
-    std::valarray<bool> ToFit;
-    size_t parameterIndex;
+    std::unordered_map<std::string, double> par;
+    std::unordered_map<std::string, bool> ToFit;
+    std::string parameterName;
 
 public:
     double operator()(double dParam);
@@ -24,7 +24,7 @@ public:
 
     [[nodiscard]] std::tuple<std::valarray<double>, std::valarray<double>> resample() const;
 
-    explicit IVParamFitter(size_t parIndex);
+    explicit IVParamFitter();
 };
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,7 @@
 int main() {
     const std::chrono::time_point<std::chrono::steady_clock> beginning = std::chrono::steady_clock::now();
     try {
-        IVParamFitter foo(0);
+        IVParamFitter foo;
         foo.loadExperimentData(fname);
         foo.CEB_2eq_parallel_lite();
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -38,7 +38,7 @@ std::tuple<std::valarray<double>, std::valarray<double>> getExperimentalData(
     std::clog << "Fitting for " << std::quoted(filename) << " started!" << std::endl;
 
     if (std::ofstream params("fitparameters_new.txt", std::ios::app); params) {
-        params << "Filename: " << std::quoted(filename) << std::endl;
+        params << "data source = " << std::quoted(filename) << std::endl;
         params.close();
     } else {
         throw std::runtime_error("Unable to append to \"fitparameters_new.txt\"");


### PR DESCRIPTION
Accessing the fit parameters by name allows changing the order and the number of the parameters in the `startparams.txt` file. This makes the file processing more flexible. As the parameters are stored in [an unordered map](https://en.cppreference.com/w/cpp/container/unordered_map), the access to the items has constant-time complexity.

The structure of the `fitparameters_new.txt` file has also been changed to accommodate possibly unordered parameters. Now the parameters are named, not only the values are written.